### PR TITLE
Non blocking poll recv

### DIFF
--- a/config.h
+++ b/config.h
@@ -22,4 +22,7 @@
 /* Define to 1 if the system has the function `pthread_barrier_init'. */
 #define HAVE_PTHREAD_BARRIER_INIT 1
 
+/* define to use non-blocking recv for poll_recv() */
+#define POLL_RECV_USING_NONBLOCKING
+
 #endif /* CONFIG_H_SEEN */

--- a/mcperf.cc
+++ b/mcperf.cc
@@ -157,12 +157,28 @@ bool poll_recv(zmq::socket_t& socket, zmq::message_t& msg) {
 	D("- recv"); 
 	//if no timeout, just block
 	if (timer == 0) { 
+#ifdef POLL_RECV_USING_NONBLOCKING
+#ifdef ZMQ_CPP11
+		while (1) {
+			if (socket.recv(msg, recv_noblock_flag).has_value()) {
+				return true;
+			}
+		}
+#else
+		while (1) {
+			if (socket.recv(msg, recv_noblock_flag)) {
+				return true;
+			}
+		}
+#endif
+#else
 #ifdef ZMQ_CPP11
 		auto recv_result = socket.recv(msg);
 		return recv_result.has_value();
 #else
 		return socket.recv(msg);
 #endif
+#endif /* POLL_RECV_USING_NONBLOCKING */
 	}
 	//otherwise, recv non blocking until timeout passed
 	int itid=0;


### PR DESCRIPTION
Hello,

These patches address some issues I have been having with performance reproducibility.  

The first patch addresses the warnings about using deprecated methods in zmq.hpp when compiled using C++11.

The second patch improves synchronization between the leader mcperf and its agents in order to reliably have fully concurrent load generation.

James